### PR TITLE
Patch fixing an inconsistency

### DIFF
--- a/ajax_select/fields.py
+++ b/ajax_select/fields.py
@@ -224,6 +224,15 @@ class AutoCompleteSelectMultipleField(forms.fields.CharField):
         super(AutoCompleteSelectMultipleField, self).__init__(*args, **kwargs)
 
     def clean(self, value):
+        if value:
+            lookup = get_lookup(self.channel)
+            objs = lookup.get_objects(value)
+            if len(objs) != len(value):
+                # someone else might have deleted it while you were editing
+                # or your channel is faulty
+                # out of the scope of this field to do anything more than tell you it doesn't exist
+                raise forms.ValidationError(u"%s cannot find all objects: %s" % (lookup,value))
+
         if not value and self.required:
             raise forms.ValidationError(self.error_messages['required'])
         return value # a list of IDs from widget value_from_datadict


### PR DESCRIPTION
Hi, first i want to say that I use django-ajax-selects for a long time and it's really great!

I hacked a LookupChannel that returns non-existing items in get_query, items would be created by get_objects. That didn't work with M2M so after some debugging i figured that AutoCompleteSelectMultipleField.clean did not call get_objects like AutoCompleteSelectField.clean.

This patch addresses this issue, making the clean() behaviour consistent between AutoCompleteSelectMultipleField and AutoCompleteSelectField.

Looking forward to read you
