### PR TITLE
Small fix in CSS

### DIFF
--- a/ajax_select/static/css/ajax_select.css
+++ b/ajax_select/static/css/ajax_select.css
@@ -1,4 +1,3 @@
-
 .results_on_deck .ui-icon-trash {
 	float: left;
 	cursor: pointer;
@@ -32,6 +31,7 @@ tldr: it just works. set max-width if you want it wider
 */
 	margin: 0;
 	padding: 0;
+	position: absolute;
 }
 ul.ui-autocomplete li {
     list-style-type: none;


### PR DESCRIPTION
Hi there,

There seemed to be a small bug in the css file. Using Firefox, the display window spans the whole page, and using the custom renderItemHTML function as provided, this extra length was turned into extra height. Either way, forcing "display: absolute" on the UL fixes this problem.

Thanks for this app - it's awesome!
