### PR TITLE
Support "development mode" installation using setup.py develop

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from ez_setup import use_setuptools
+    use_setuptools()
+    from setuptools import setup
 
 setup(name='django-ajax-selects',
     version='1.2.4',


### PR DESCRIPTION
I've hacked setup.py to support [development mode installation](http://packages.python.org/distribute/setuptools.html#development-mode).  I find this useful for doing development work.
