### PR TITLE
Allowing https on all libs in templates/ajax_select/bootstrap.html

### DIFF
--- a/ajax_select/templates/ajax_select/bootstrap.html
+++ b/ajax_select/templates/ajax_select/bootstrap.html
@@ -8,7 +8,7 @@ if (typeof jQuery == 'undefined') {
 }
 if(typeof jQuery == 'undefined' || (typeof jQuery.ui == 'undefined')) {
 	document.write('<script type="text/javascript"  src="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js"><\/script>');
-	document.write('<link type="text/css" rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.7.2/themes/smoothness/jquery-ui.css" />');
+	document.write('<link type="text/css" rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.7.2/themes/smoothness/jquery-ui.css" />');
 }
 //]]>
 </script>


### PR DESCRIPTION
Hello

Here is the smallest patch ever for allowing https on all libs in templates/ajax_select/bootstrap.html

(last lib was in http only)

Hope you will accept it.

Colin.
