### PR TITLE
Never load loading image from github

### DIFF
--- a/ajax_select/static/css/ajax_select.css
+++ b/ajax_select/static/css/ajax_select.css
@@ -13,7 +13,7 @@ form .aligned .results_on_deck {
 	margin-bottom: 0.5em;
 }
 .ui-autocomplete-loading {
-	background:  url('https://github.com/crucialfelix/django-ajax-selects/raw/master/ajax_select/static/images/loading-indicator.gif') no-repeat;
+	background:  url(../images/loading-indicator.gif) no-repeat;
     background-origin: content-box;
 	background-position: right;
 }


### PR DESCRIPTION
Some older versions of Webkit browsers like to download all images found in css,
even if overriden by a later rule. Better to provide a sane default for production
environnements from the start.

Thanks!
