### PR TITLE
Use {{ current_id }} instead of {{ current_repr }} in value

### DIFF
--- a/ajax_select/templates/autocomplete.html
+++ b/ajax_select/templates/autocomplete.html
@@ -1,5 +1,5 @@
 {% if bootstrap %}{% include "ajax_select/bootstrap.html" %}{% endif %}
-<input type="text" name="{{name}}" id="{{html_id}}" value="{{current_repr}}" autocomplete="off" {{ extra_attrs }} />
+<input type="text" name="{{name}}" id="{{html_id}}" value="{{current_id}}" autocomplete="off" {{ extra_attrs }} />
 <script type="text/javascript">//<![CDATA[
 jQuery(document).ready(function($){
 {% block script %}


### PR DESCRIPTION
I wonder if the correct var to use is not "current_id" instead of "current_repr", as we are in an input value ?
It seems that current_repr and current_id are, at the moment, populated in the same way for the AutoCompleteWidget: https://github.com/crucialfelix/django-ajax-selects/blob/master/ajax_select/fields.py#L302
But for consistency, it seems to me that an "id" is more welcome than a "repr" in an input value ;)
But maybe I'm missing something.
Thanks for your enlightenments! :)
