### PR TITLE
Fixes #23: "add" links not working

### DIFF
--- a/ajax_select/fields.py
+++ b/ajax_select/fields.py
@@ -361,10 +361,10 @@ def _check_can_add(self,user,model):
 
 def autoselect_fields_check_can_add(form,model,user):
     """ check the form's fields for any autoselect fields and enable their widgets with + sign add links if permissions allow"""
-    for name,form_field in form.declared_fields.iteritems():
-        if isinstance(form_field,(AutoCompleteSelectMultipleField,AutoCompleteSelectField)):
+    for name in form.declared_fields.keys():
+        if isinstance(form.fields[name],(AutoCompleteSelectMultipleField,AutoCompleteSelectField)):
             db_field = model._meta.get_field_by_name(name)[0]
-            form_field.check_can_add(user,db_field.rel.to)
+            form.fields[name].check_can_add(user,db_field.rel.to)
 
 def plugin_options(channel,channel_name,widget_plugin_options,initial):
     """ Make a JSON dumped dict of all options for the jquery ui plugin itself """


### PR DESCRIPTION
I believe iteritems() was instantiating a copy of the form field, as opposed to instantiating a reference to it, so the changes going on in check_can_add() were not making it back out to the actual form. This change ensures that the fields actually attached to the form get the changes when autoselect_fields_check_can_add() is called.
