### PR TITLE
static files issue when using setting AJAX_SELECT_INLINES = 'staticfiles'

### DIFF
--- a/ajax_select/fields.py
+++ b/ajax_select/fields.py
@@ -401,10 +401,7 @@ def bootstrap():
         js = f.read()
         b['inline'] = mark_safe(u"""<style type="text/css">%s</style><script type="text/javascript">//<![CDATA[%s//]]></script>""" % (css,js))
     elif inlines == 'staticfiles':
-        if django.get_version() >= '1.4.0':
-            b['inline'] = mark_safe("""<style type="text/css">@import url("%scss/ajax_select.css");</style><script type="text/javascript" src="%sjs/ajax_select.js"></script>""" % (settings.STATIC_URL,settings.STATIC_URL))
-        else:
-            b['inline'] = mark_safe("""<style type="text/css">@import url("%sajax_select/css/ajax_select.css");</style><script type="text/javascript" src="%sajax_select/js/ajax_select.js"></script>""" % (settings.STATIC_URL,settings.STATIC_URL))
+        b['inline'] = mark_safe("""<style type="text/css">@import url("%scss/ajax_select.css");</style><script type="text/javascript" src="%sjs/ajax_select.js"></script>""" % (settings.STATIC_URL,settings.STATIC_URL))
 
     return b
 


### PR DESCRIPTION
django 1.4+ staticifles app doesn't prefix media files with app name when running manage.py collectstatic.
This in turn breaks templates.

*\* Thanks for the great work you did on this app! **
