### PR TITLE
Clear deck before putting initial items in.

### DIFF
--- a/ajax_select/static/js/ajax_select.js
+++ b/ajax_select/static/js/ajax_select.js
@@ -117,6 +117,7 @@ $.fn.autocompleteselectmultiple = function(options) {
 		$text.autocompletehtml();
 
 		if (options.initial) {
+			$deck.empty();
 			$.each(options.initial, function(i, its) {
 				addKiller(its[0], its[1]);
 			});


### PR DESCRIPTION
For some reason the plugin was loading up twice in my setup.
Everything worked fine, except that I was seeing duplicate initial items in AutoCompleteSelectMultipleFields.

This fixes it.
