### PR TITLE
add_link added [ very easy ]

### DIFF
--- a/ajax_select/fields.py
+++ b/ajax_select/fields.py
@@ -31,6 +31,7 @@ class AutoCompleteSelectWidget(forms.widgets.TextInput):
                  plugin_options = {},
                  *args, **kwargs):
         self.plugin_options = plugin_options
+        self.add_link = plugin_options.get('add_link')
         super(forms.widgets.TextInput, self).__init__(*args, **kwargs)
         self.channel = channel
         self.help_text = help_text
@@ -282,6 +283,7 @@ class AutoCompleteWidget(forms.TextInput):
         self.help_text = kwargs.pop('help_text', '')
         self.show_help_text = kwargs.pop('show_help_text',True)
         self.plugin_options = kwargs.pop('plugin_options',{})
+        self.add_link = kwargs.pop('add_link', '')
 
         super(AutoCompleteWidget, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
Add link allows you tu specify adding link. It is included in the jquery plugin. You only pass the parameter to the plugin_options.

Example:

```
 model = AutoCompleteSelectField(                                            
        'asset_model', required=True,                                           
        plugin_options=dict(add_link='/admin/assets/assetmodel/add/?name=')                                                                                                       
    )
```

See attachment for effect:

[Zrzut ekranu 2012-12-14 o 11 15 29](https://f.cloud.github.com/assets/552398/12993/577a894e-45d7-11e2-931b-5c88d7d900bc.png)
