### PR TITLE
Improve JavaScript support (autocomplete fix)

### DIFF
--- a/ajax_select/static/js/ajax_select.js
+++ b/ajax_select/static/js/ajax_select.js
@@ -1,4 +1,3 @@
-
 if(typeof jQuery.fn.autocompletehtml != 'function') {
 
 (function($) {
@@ -10,7 +9,7 @@ $.fn.autocompletehtml = function() {
                 autoComplete = this.data("autocomplete");
         }
 	
-	autoComplete.data("autocomplete")._renderItem = function _renderItemHTML(ul, item) {
+	autoComplete._renderItem = function _renderItemHTML(ul, item) {
 		if(sizeul) {
 			if(ul.css('max-width')=='none') ul.css('max-width',$text.outerWidth());
 			sizeul = false;


### PR DESCRIPTION
Improved https://github.com/crucialfelix/django-ajax-selects/pull/44/files#r3610996.
Just another try for jquery autocomplete issue (quick hack for saving backward compactibility).
Tested with jquery 1.9.1 & jquery-ui 1.10.1 (no errors).
