### PR TITLE
Update urls.py

### DIFF
--- a/ajax_select/urls.py
+++ b/ajax_select/urls.py
@@ -1,5 +1,4 @@
-
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 
 urlpatterns = patterns('',


### PR DESCRIPTION
django.conf.urls.defaults is depreciated:

DeprecationWarning: django.conf.urls.defaults is deprecated; use django.conf.urls instead
