### PR TITLE
Provide option to render autocomplete results in html input fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 Enables editing of `ForeignKey`, `ManyToMany` and `CharField` using jQuery UI Autocomplete.
 
 User experience
@@ -266,6 +265,7 @@ Set any options for the jQuery plugin. This includes:
 + disabled
 + position
 + source - setting this would overide the normal ajax URL. could be used to add URL query params
++ render_in_input - setting this to True will render the response in an AutoCompleteSelect input field, rather than in the deck below the input
 
 See http://docs.jquery.com/UI/Autocomplete#options
 
@@ -548,5 +548,3 @@ License
 Dual licensed under the MIT and GPL licenses:
    http://www.opensource.org/licenses/mit-license.php
    http://www.gnu.org/licenses/gpl.html
-
-

--- a/ajax_select/static/ajax_select/js/ajax_select.js
+++ b/ajax_select/static/ajax_select/js/ajax_select.js
@@ -9,13 +9,27 @@
           $text = $('#' + id + '_text'),
           $deck = $('#' + id + '_on_deck');
 
+      function renderResult(repr, pk) {
+        /*
+         * Render the autocomplete response. By default the repr is
+         * added to a killable deck below the input field. If
+         * options.render_in_input is true the repr will be added to
+         * the input field and the deck ignored.
+         */
+        if (options.render_in_input) {
+          $text.val(repr);
+        } else {
+          $text.val('')
+          addKiller(repr, pk);
+        }
+      }
+
       function receiveResult(event, ui) {
         if ($this.val()) {
           kill();
         }
         $this.val(ui.item.pk);
-        $text.val('');
-        addKiller(ui.item.repr);
+        renderResult(ui.item.repr, ui.item.pk);
         $deck.trigger('added', [ui.item.pk, ui.item]);
 
         return false;
@@ -45,7 +59,7 @@
       $text.autocomplete(options);
 
       if (options.initial) {
-        addKiller(options.initial[0], options.initial[1]);
+        renderResult(options.initial[0], options.initial[1]);
       }
 
       $this.bind('didAddPopup', function (event, pk, repr) {


### PR DESCRIPTION
AutoCompleteSelect fields should be able to render the selected result in the input field rather than the deck below the input.

Specifically, given the example lookup field defined by:
```python
class TestLookupField(OpenLookupChannel):
    model = TestModel
    plugin_options = {
        'render_in_input': True,
    }
```

The resulting webpage shows:
![res1](https://f.cloud.github.com/assets/1124536/1555751/3793c28c-4e80-11e3-8837-65be9dc7cdcc.png)

Instead of:
![res2](https://f.cloud.github.com/assets/1124536/1555752/3a571744-4e80-11e3-89be-3baed5acdd2e.png)