### PR TITLE
Trigger the change event for the hidden input.

### DIFF
--- a/ajax_select/static/ajax_select/js/ajax_select.js
+++ b/ajax_select/static/ajax_select/js/ajax_select.js
@@ -17,6 +17,7 @@
         $text.val('');
         addKiller(ui.item.repr);
         $deck.trigger('added', [ui.item.pk, ui.item]);
+        $this.trigger("change");
 
         return false;
       }
@@ -70,6 +71,7 @@
           addKiller(ui.item.repr, pk);
           $text.val('');
           $deck.trigger('added', [ui.item.pk, ui.item]);
+          $this.trigger("change");
         }
         return false;
       }


### PR DESCRIPTION
This fixes: https://github.com/digi604/django-smart-selects/issues/32

The hidden input doesn't trigger the `change` event, so we have to trigger it ourselves.
