### PR TITLE
Update __init__.py

### DIFF
--- a/ajax_select/__init__.py
+++ b/ajax_select/__init__.py
@@ -105,7 +105,7 @@ def make_ajax_form(model, fieldlist, superclass=ModelForm, show_help_text=False,
 
         TheForm.declared_fields[model_fieldname] = f
         TheForm.base_fields[model_fieldname] = f
-        setattr(TheForm, model_fieldname, f)
+        #setattr(TheForm, model_fieldname, f)
 
     return TheForm
 


### PR DESCRIPTION
integrated Patch https://code.google.com/p/django-ajax-selects/issues/detail?id=80 in order to fix for Media-Fields

Fixes an issue that shows, if a model has a field named 'media', which leads to a naming collision in the end.
