### PR TITLE
maintain compatibility with Python 2.6

### DIFF
--- a/ajax_select/fields.py
+++ b/ajax_select/fields.py
@@ -18,7 +18,7 @@ except ImportError:
 
 
 as_default_help = 'Enter text to search.'
-IS_PYTHON2 = sys.version_info.major == 2
+IS_PYTHON2 = sys.version_info[0] == 2
 
 
 def _to_number(got):


### PR DESCRIPTION
I would like to propose to maintain compatibility with Python 2.6 by not making use of named component attributes of sys,version_info introduced in Python 2.7. Of course, if some other part of the code relies on Python 2.7, this change would not really make sense.
