### PR TITLE
Support non-int primary keys

### DIFF
--- a/ajax_select/__init__.py
+++ b/ajax_select/__init__.py
@@ -49,7 +49,8 @@ class LookupChannel(object):
         # this will be however the related objects Manager returns them
         # which is not guaranteed to be the same order they were in when you last edited
         # see OrdredManyToMany.md
-        ids = [int(id) for id in ids]
+        pk_type = self.model._meta.pk.to_python
+        ids = [pk_type(id) for id in ids]
         things = self.model.objects.in_bulk(ids)
         return [things[aid] for aid in ids if aid in things]
 


### PR DESCRIPTION
Currently, `LookupChannel.get_objects()` uses `int()` to parse string PK values. This means that models without an int PK will return nothing, so our form fields don't get initial values set.

This change replaces the call to `int()` with a call to `self.model._meta.pk.to_python()`, which should always return the key in the correct type, ready to be used in an ORM query.

I see some ids are converted to ints in `value_from_datadict()` as well - those places might need attention too?
