### PR TITLE
Change kwarg for HttpResponse in views.py

### DIFF
--- a/ajax_select/views.py
+++ b/ajax_select/views.py
@@ -44,7 +44,7 @@ def ajax_lookup(request, channel):
         } for item in instances
     ])
 
-    return HttpResponse(results, mimetype='application/javascript')
+    return HttpResponse(results, content_type='application/javascript')
 
 
 def add_popup(request, app_label, model):


### PR DESCRIPTION
The 'mimetype' kwarg has been deprecated for 'HttpResponse' since Django 1.4, switched it out for 'content_type'.
