### PR TITLE
Django's HttpResponse object has deprecated the mimetype kwarg in 1.7

### DIFF
--- a/ajax_select/views.py
+++ b/ajax_select/views.py
@@ -44,7 +44,7 @@ def ajax_lookup(request, channel):
         } for item in instances
     ])
 
-    return HttpResponse(results, mimetype='application/javascript')
+    return HttpResponse(results, content_type='application/javascript')
 
 
 def add_popup(request, app_label, model):


### PR DESCRIPTION
The `mimetype` kwarg has been deprecated in favour of `content_type` which has been present in Django since 1.4. (see https://docs.djangoproject.com/en/1.7/ref/request-response/#id3)

https://docs.djangoproject.com/en/1.4/ref/request-response/
_content_type is an alias for mimetype. Historically, this parameter was only called mimetype, but since this    is actually the value included in the HTTP Content-Type header, it can also include the character set encoding, which makes it more than just a MIME type specification. If mimetype is specified (not None), that value is used. Otherwise, content_type is used. If neither is given, the DEFAULT_CONTENT_TYPE setting is used._

This change will break backwards compatibility with Django 1.3 and earlier.
