### PR TITLE
Ability to define widget channel_options that get added as LookupChannel attributes

### DIFF
--- a/ajax_select/__init__.py
+++ b/ajax_select/__init__.py
@@ -23,6 +23,10 @@ class LookupChannel(object):
     plugin_options = {}
     min_length = 1
 
+    def __init__(self, **kwargs):
+        self.__dict__.update(**kwargs)
+        super(LookupChannel, self).__init__()
+
     def get_query(self, q, request):
         """ return a query set searching for the query string q
             either implement this method yourself or set the search_field
@@ -162,7 +166,7 @@ def make_ajax_field(model, model_fieldname, channel, show_help_text=False, **kwa
 
 ####################  private  ##################################################
 
-def get_lookup(channel):
+def get_lookup(channel, **channel_options):
     """ find the lookup class for the named channel.  this is used internally """
     try:
         lookup_label = settings.AJAX_LOOKUP_CHANNELS[channel]
@@ -195,7 +199,7 @@ def get_lookup(channel):
                 getattr(lookup_class, 'format_result',
                     lambda self, obj: force_text(obj)))
 
-        return lookup_class()
+        return lookup_class(**channel_options)
 
 
 def make_channel(app_model, arg_search_field):

--- a/ajax_select/fields.py
+++ b/ajax_select/fields.py
@@ -282,7 +282,7 @@ class AutoCompleteSelectMultipleField(forms.fields.CharField):
             'channel': channel,
             'help_text': help_text,
             'show_help_text': show_help_text,
-            'channel_options': kwargs.pop('channel_options', {})
+            'channel_options': kwargs.pop('channel_options', {}),
             'plugin_options': kwargs.pop('plugin_options', {})
         }
         kwargs['widget'] = AutoCompleteSelectMultipleWidget(**widget_kwargs)

--- a/ajax_select/fields.py
+++ b/ajax_select/fields.py
@@ -55,9 +55,11 @@ class AutoCompleteSelectWidget(forms.widgets.TextInput):
                  channel,
                  help_text='',
                  show_help_text=True,
+                 channel_options={},
                  plugin_options={},
                  *args,
                  **kwargs):
+        self.channel_options = channel_options
         self.plugin_options = plugin_options
         super(forms.widgets.TextInput, self).__init__(*args, **kwargs)
         self.channel = channel
@@ -72,7 +74,7 @@ class AutoCompleteSelectWidget(forms.widgets.TextInput):
 
         current_repr = ''
         initial = None
-        lookup = get_lookup(self.channel)
+        lookup = get_lookup(self.channel, **self.channel_options)
         if value:
             objs = lookup.get_objects([value])
             try:
@@ -128,6 +130,7 @@ class AutoCompleteSelectField(forms.fields.CharField):
                 channel=channel,
                 help_text=kwargs.get('help_text', _(as_default_help)),
                 show_help_text=kwargs.pop('show_help_text', True),
+                channel_options=kwargs.pop('channel_options', {}),
                 plugin_options=kwargs.pop('plugin_options', {})
             )
             kwargs["widget"] = AutoCompleteSelectWidget(**widget_kwargs)
@@ -167,6 +170,7 @@ class AutoCompleteSelectMultipleWidget(forms.widgets.SelectMultiple):
                  channel,
                  help_text='',
                  show_help_text=True,
+                 channel_options={},
                  plugin_options={},
                  *args,
                  **kwargs):
@@ -175,6 +179,7 @@ class AutoCompleteSelectMultipleWidget(forms.widgets.SelectMultiple):
 
         self.help_text = help_text
         self.show_help_text = show_help_text
+        self.channel_options = channel_options
         self.plugin_options = plugin_options
 
     def render(self, name, value, attrs=None):
@@ -185,7 +190,7 @@ class AutoCompleteSelectMultipleWidget(forms.widgets.SelectMultiple):
         final_attrs = self.build_attrs(attrs)
         self.html_id = final_attrs.pop('id', name)
 
-        lookup = get_lookup(self.channel)
+        lookup = get_lookup(self.channel, **self.channel_options)
 
         # eg. value = [3002L, 1194L]
         if value:
@@ -277,6 +282,7 @@ class AutoCompleteSelectMultipleField(forms.fields.CharField):
             'channel': channel,
             'help_text': help_text,
             'show_help_text': show_help_text,
+            'channel_options': kwargs.pop('channel_options', {})
             'plugin_options': kwargs.pop('plugin_options', {})
         }
         kwargs['widget'] = AutoCompleteSelectMultipleWidget(**widget_kwargs)


### PR DESCRIPTION
Sometimes it would be useful to be able to pass options through to the LookupChannel to affect the results based on the form being used, in particular when editing existing model instances. For example, consider the following setup:

    class Event(models.Model):
        users = models.ManyToManyField(settings.AUTH_USER_MODEL, through="EventMembership")
    
    class EventMembership(models.Model):
        user = models.ForeignKey(
            settings.AUTH_USER_MODEL,
            related_name="memberships",
        )
        event = models.ForeignKey(
            Event,
            related_name="registrants",
        )
        status = models.CharField(
            max_length=10,
            choices=MEMBERSHIP_STATUS,
        )

With the form as follows:

    class EventForm(forms.ModelForm):
        users = AutoCompleteSelectMultipleField('users')

        class Meta:
            model = Event

If you are editing an Event and you want to colour-code the users based on EventMembership.status, this is not currently possible as the data resides in the through table. Instead you would need to pass the Event instance pk through to the lookup channel so that format_item_display could retrieve the record and adjust the display as such. With the changes in this pull request this could be achieved simply as follows:

    class EventForm(forms.ModelForm):
        users = AutoCompleteSelectMultipleField('judges')
    
        class Meta:
            model = Event
    
        def __init__(self, *args, **kwargs):
            super(EventForm, self).__init__(*args, **kwargs)
            self.fields['users'].widget.channel_options.update({'event_id': self.instance.pk})

The LookupChannel would then have the attribute "event_id" that could be used to retrieve the membership status within get_objects by doing EventMembership.objects.filter(user_id__in=ids, event_id=self.event_id)