### PR TITLE
Added option for fields in TheForm superclass

### DIFF
--- a/ajax_select/__init__.py
+++ b/ajax_select/__init__.py
@@ -92,7 +92,7 @@ def make_ajax_form(model, fieldlist, superclass=ModelForm, show_help_text=False,
     class TheForm(superclass):
 
         class Meta:
-            pass
+            fields = '__all__'
         setattr(Meta, 'model', model)
         if hasattr(superclass, 'Meta'):
             if hasattr(superclass.Meta, 'fields'):


### PR DESCRIPTION
Using the latest version of django (1.8), I was getting a ModelForm error whenever I used ```make_ajax_form```. Turns out that it is now a requirement for the fields attribute (or exclude) to be included when creating a form, [according to the docs](https://docs.djangoproject.com/en/dev/topics/forms/modelforms/#selecting-the-fields-to-use). Adding ```__all__``` seemed to resolve the issue. 