### PR TITLE
Improve the example application

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Features
 + JQuery triggers allow you to customize interface behavior to respond when items are added or removed
 + Default (but customizable) security prevents griefers from pilfering your data via JSON requests
 
-
+Supported Django version: 1.6 and newer
 
 Quick Installation
 ==================

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -19,6 +19,12 @@ INSTALLED_APPS = (
 
 ###########################################################################
 
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+)
+
 # DEFINE THE SEARCH CHANNELS:
 
 AJAX_LOOKUP_CHANNELS = {

--- a/example/install.sh
+++ b/example/install.sh
@@ -16,13 +16,14 @@ else
     pip install django
 fi
 
-echo "Creating a sqllite database:"
-./manage.py syncdb
 
 if [ ! -d ./ajax_select ]; then
 	echo "\nSymlinking ajax_select into this app directory:"
 	ln -s ../ajax_select/ ./ajax_select
 fi
+
+echo "Creating a sqllite database:"
+./manage.py syncdb
 
 echo "\nto activate the virtualenv:\nsource AJAXSELECTS/bin/activate"
 


### PR DESCRIPTION
Fix the installation process by running syncdb after symlinking the app. Explicitely declare MIDDLEWARE_CLASSES in settings.

Note: this break supports for Django versions older than 1.6. I documented this in the README. Which Django versions are supported by this project? Please let me know if any older Django version needs to be supported (LTS support for 1.4 ends in March 2015) and I will update the PR accordingly. Thanks.