### PR TITLE
Change order for running script by .sh #112 (NOTICE)

### DIFF
--- a/example/install.sh
+++ b/example/install.sh
@@ -16,13 +16,13 @@ else
     pip install django
 fi
 
-echo "Creating a sqllite database:"
-./manage.py syncdb
-
 if [ ! -d ./ajax_select ]; then
 	echo "\nSymlinking ajax_select into this app directory:"
 	ln -s ../ajax_select/ ./ajax_select
 fi
+
+echo "Creating a sqllite database:"
+./manage.py syncdb
 
 echo "\nto activate the virtualenv:\nsource AJAXSELECTS/bin/activate"
 


### PR DESCRIPTION
Fixed `ImportError: No module named ajax_select` #112

```
jakubnowak@MBP-Jakub:example (develop) $ ./install.sh 
New python executable in AJAXSELECTS/bin/python
Installing setuptools, pip...done.
Installing latest django:
Downloading/unpacking django
  Downloading Django-1.7.7-py2.py3-none-any.whl (7.4MB): 7.4MB downloaded
Installing collected packages: django
Successfully installed django
Cleaning up...
Creating a sqllite database:
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/Users/jakubnowak/Desktop/repo/django-ajax-selects/example/AJAXSELECTS/lib/python2.7/site-packages/django/core/management/__init__.py", line 385, in execute_from_command_line
    utility.execute()
  File "/Users/jakubnowak/Desktop/repo/django-ajax-selects/example/AJAXSELECTS/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute
    django.setup()
  File "/Users/jakubnowak/Desktop/repo/django-ajax-selects/example/AJAXSELECTS/lib/python2.7/site-packages/django/__init__.py", line 21, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/Users/jakubnowak/Desktop/repo/django-ajax-selects/example/AJAXSELECTS/lib/python2.7/site-packages/django/apps/registry.py", line 85, in populate
    app_config = AppConfig.create(entry)
  File "/Users/jakubnowak/Desktop/repo/django-ajax-selects/example/AJAXSELECTS/lib/python2.7/site-packages/django/apps/config.py", line 87, in create
    module = import_module(entry)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
ImportError: No module named ajax_select

```