### PR TITLE
Reset button handling

### DIFF
--- a/ajax_select/static/ajax_select/js/ajax_select.js
+++ b/ajax_select/static/ajax_select/js/ajax_select.js
@@ -45,10 +45,6 @@
       options.select = receiveResult;
       $text.autocomplete(options);
 
-      if (options.initial) {
-        addKiller(options.initial[0], options.initial[1]);
-      }
-
       function reset(){
         if (options.initial) {
           addKiller(options.initial[0], options.initial[1]);

--- a/ajax_select/static/ajax_select/js/ajax_select.js
+++ b/ajax_select/static/ajax_select/js/ajax_select.js
@@ -49,6 +49,18 @@
         addKiller(options.initial[0], options.initial[1]);
       }
 
+      function reset(){
+        if (options.initial) {
+          addKiller(options.initial[0], options.initial[1]);
+          $this.val(options.initial[1]);
+        } else {
+          kill();
+        }
+      };
+
+      reset();
+      $this.closest('form').on('reset', reset);
+
       $this.bind('didAddPopup', function (event, pk, repr) {
         receiveResult(null, {item: {pk: pk, repr: repr}});
       });
@@ -95,11 +107,20 @@
       options.select = receiveResult;
       $text.autocomplete(options);
 
-      if (options.initial) {
-        $.each(options.initial, function (i, its) {
-          addKiller(its[0], its[1]);
-        });
-      }
+      function reset(){
+        $deck.empty();
+        var query = "|";
+        if (options.initial) {
+          $.each(options.initial, function (i, its) {
+            addKiller(its[0], its[1]);
+            query += its[1] + "|";
+          });
+        }
+        $this.val(query);
+      };
+
+      reset();
+      $this.closest('form').on('reset', reset);
 
       $this.bind('didAddPopup', function (event, pk, repr) {
         receiveResult(null, {item: {pk: pk, repr: repr }});


### PR DESCRIPTION
Ensure reset buttons/event on containing forms are handled, giving a clean field or initial data. Also does this on page load (which, AFAIK, matches the existing behavior).

I also assumed that a 'reset' shouldn't send any deck triggers, though that may be up for debate and is trivial to add.