### PR TITLE
Support for UUID

### DIFF
--- a/ajax_select/__init__.py
+++ b/ajax_select/__init__.py
@@ -4,6 +4,8 @@ __author__ = "crucialfelix"
 __contact__ = "crucialfelix@gmail.com"
 __homepage__ = "https://github.com/crucialfelix/django-ajax-selects/"
 
+from uuid import UUID
+from json import JSONEncoder
 from ajax_select.registry import registry, register  # noqa
 from ajax_select.helpers import make_ajax_form, make_ajax_field  # noqa
 from ajax_select.lookup_channel import LookupChannel  # noqa
@@ -20,3 +22,10 @@ except ImportError:
     # Previous django versions should load now
     # using settings.AJAX_LOOKUP_CHANNELS
     registry.load_channels()
+
+def UUIDAwareJSONEncoder(JSONEncoder):
+    def default(self, o):
+        if isinstance(o, UUID):
+            return str(o)
+        else:
+            return super(UUIDAwareJSONEncoder, self).default(o)

--- a/ajax_select/fields.py
+++ b/ajax_select/fields.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 from ajax_select.registry import registry
+from ajax_select import UUIDAwareJSONEncoder
 from django import forms
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -205,7 +206,7 @@ class AutoCompleteSelectMultipleWidget(forms.widgets.SelectMultiple):
             'html_id': self.html_id,
             'current': value,
             'current_ids': current_ids,
-            'current_reprs': mark_safe(json.dumps(initial)),
+            'current_reprs': mark_safe(json.dumps(initial, cls=UUIDAwareJSONEncoder)),
             'help_text': help_text,
             'extra_attrs': mark_safe(flatatt(final_attrs)),
             'func_slug': self.html_id.replace("-", ""),
@@ -424,6 +425,6 @@ def plugin_options(lookup, channel_name, widget_plugin_options, initial):
         po['html'] = True
 
     return {
-        'plugin_options': mark_safe(json.dumps(po)),
-        'data_plugin_options': force_escape(json.dumps(po))
+        'plugin_options': mark_safe(json.dumps(po, cls=UUIDAwareJSONEncoder)),
+        'data_plugin_options': force_escape(json.dumps(po, cls=UUIDAwareJSONEncoder))
     }

--- a/ajax_select/lookup_channel.py
+++ b/ajax_select/lookup_channel.py
@@ -97,7 +97,7 @@ class LookupChannel(object):
         pk_type = self.model._meta.pk.to_python
         ids = [pk_type(pk) for pk in ids]
         things = self.model.objects.in_bulk(ids)
-        return [things[aid] for aid in ids if aid in things]
+        return things.values()
 
     def can_add(self, user, other_model):
         """Check if the user has permission to add a ForeignKey or M2M model.

--- a/ajax_select/views.py
+++ b/ajax_select/views.py
@@ -1,5 +1,5 @@
 
-from ajax_select import registry
+from ajax_select import registry, UUIDAwareJSONEncoder
 from ajax_select.registry import get_model
 from django.contrib.admin import site
 from django.contrib.admin.options import IS_POPUP_VAR
@@ -48,7 +48,7 @@ def ajax_lookup(request, channel):
             'match': lookup.format_match(item),
             'repr': lookup.format_item_display(item)
         } for item in instances
-    ])
+    ], cls=UUIDAwareJSONEncoder)
 
     return HttpResponse(results, content_type='application/json')
 


### PR DESCRIPTION
There are 2 issues when using UUIDField as primary key in Django:
- the get_object methods filters the output of the in_bulk method through the original ids parameters. When using uuids, the ids elements are strings while the keys of the in_bulk result are uuid.UUID instances, which makes the filtering fail.
- the json.dumps method does not know how to serialize uuid.UUID objects.

This pull request (against the develop branch) fixes both issues.
