### PR TITLE
Makes the killButton HTML markup configurable.

### DIFF
--- a/ajax_select/static/ajax_select/js/ajax_select.js
+++ b/ajax_select/static/ajax_select/js/ajax_select.js
@@ -9,6 +9,13 @@
           $text = $('#' + id + '_text'),
           $deck = $('#' + id + '_on_deck');
 
+      if ('killButton' in options) {
+        var killButtonTemplate = options.killButton
+        delete options.killButton
+      } else {
+        var killButtonTemplate = '<span class="ui-icon ui-icon-trash" id="{{ killId }}">X</span>'
+      }
+
       function receiveResult(event, ui) {
         if ($this.val()) {
           kill();
@@ -24,7 +31,7 @@
 
       function addKiller(repr, pk) {
         var killId = 'kill_' + pk + id,
-            killButton = '<span class="ui-icon ui-icon-trash" id="' + killId + '">X</span> ';
+            killButton = killButtonTemplate.replace('{{ killId }}', killId);
         if (repr) {
           $deck.empty();
           $deck.append('<div>' + killButton + repr + '</div>');
@@ -70,6 +77,13 @@
           $text = $('#' + id + '_text'),
           $deck = $('#' + id + '_on_deck');
 
+      if ('killButton' in options) {
+        var killButtonTemplate = options.killButton
+        delete options.killButton
+      } else {
+        var killButtonTemplate = '<span class="ui-icon ui-icon-trash" id="{{ killId }}">X</span>'
+      }
+
       function receiveResult(event, ui) {
         var pk = ui.item.pk,
             prev = $this.val();
@@ -86,7 +100,7 @@
 
       function addKiller(repr, pk) {
         var killId = 'kill_' + pk + id,
-            killButton = '<span class="ui-icon ui-icon-trash" id="' + killId + '">X</span> ';
+            killButton = killButtonTemplate.replace('{{ killId }}', killId);
         $deck.append('<div id="' + id + '_on_deck_' + pk + '">' + killButton + repr + ' </div>');
 
         $('#' + killId).click(function() {


### PR DESCRIPTION
I'd like to use django-ajax-selects, but not in admin. The whole styling in my case is based on bootstrap and elusive font and i want the kill button not to be styled using jquery ui.

Therefore this patch makes it possible to hand over a HTML template for the killButton using the plugin options available in the corresponding fields.

```
plugin_options={'killButton': '<i class="el-icon-remove" id="{{ killId }}"></i>'}
```

This feels a little hacky, because it misuses the jquery options...

Another approach would be to make the method addKiller overridable, instead of a local method - if you prefer this or another approach, let me know - i will try provide another patch ...