### PR TITLE
Fix incorrect has_changed result for AutoCompleteSelectField that has not been filled in.

### DIFF
--- a/ajax_select/fields.py
+++ b/ajax_select/fields.py
@@ -140,8 +140,10 @@ class AutoCompleteSelectField(forms.fields.CharField):
     def check_can_add(self, user, model):
         _check_can_add(self, user, model)
 
-    def has_changed(self, initial_value, data_value):
+    def has_changed(self, initial, data):
         # 1 vs u'1'
+        initial_value = initial if initial is not None else ''
+        data_value = data if data is not None else ''
         return text_type(initial_value) != text_type(data_value)
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -36,6 +36,9 @@ class TestAutoCompleteSelectField(TestCase):
         self.assertFalse(field.has_changed(1, '1'))
         self.assertFalse(field.has_changed('abc', 'abc'))
         self.assertTrue(field.has_changed(1, '2'))
+        self.assertFalse(field.has_changed(None, ''))
+        self.assertFalse(field.has_changed(None, None))
+        self.assertFalse(field.has_changed('', None))
 
 
 class TestAutoCompleteSelectMultipleField(TestCase):


### PR DESCRIPTION
A fix for empty inlines incorrectly showing as "changed", thus preventing form submissions. 

The solution proposed in this PR is very much the same as [`ModelChoiceField.has_changed`](https://github.com/django/django/blob/1.9.1/django/forms/models.py#L1220).

As @crucialfelix mentioned in #142, it would be more correct for `AutoCompleteSelectField` to rather inherit from `ModelChoiceField`, and probably by extension, `AutoCompleteSelectMultipleField` should inherit from `ModelMultipleChoiceField`.

Changing the fields' inheritance would have far-reaching consequences and will take longer to implement, so this PR only deals with the immediate issue, not the correctness of the class inheritance.