### PR TITLE
Fixes re-initialization upon adding inlines

### DIFF
--- a/ajax_select/static/ajax_select/js/ajax_select.js
+++ b/ajax_select/static/ajax_select/js/ajax_select.js
@@ -228,8 +228,8 @@
     // if dynamically injecting forms onto a page
     // you can trigger them to be ajax-selects-ified:
     $(window).trigger('init-autocomplete');
-    $('.inline-group ul.tools a.add, .inline-group div.add-row a, .inline-group .tabular tr.add-row td a')
-      .on('click', function() {
+    $(document)
+      .on('click', '.inline-group ul.tools a.add, .inline-group div.add-row a, .inline-group .tabular tr.add-row td a', function() {
         $(window).trigger('init-autocomplete');
       });
   });


### PR DESCRIPTION
the rationale is that the elements an event are bound to must exist. this isn't the case for the specified selectors.
i'd appreciate if this was released soon.

solves #87