### PR TITLE
Stop using deprecated _meta api.

### DIFF
--- a/ajax_select/fields.py
+++ b/ajax_select/fields.py
@@ -407,7 +407,7 @@ def autoselect_fields_check_can_add(form, model, user):
     """
     for name, form_field in form.declared_fields.items():
         if isinstance(form_field, (AutoCompleteSelectMultipleField, AutoCompleteSelectField)):
-            db_field = model._meta.get_field_by_name(name)[0]
+            db_field = model._meta.get_field(name)
             form_field.check_can_add(user, db_field.rel.to)
 
 


### PR DESCRIPTION
As stated in django documentation: https://docs.djangoproject.com/en/1.8/ref/models/meta/#migrating-old-meta-api
get_field_by_name is deprecated