### PR TITLE
Fix "add new item" for data-ajax-select="autocompletemultiple" fields

### DIFF
--- a/ajax_select/static/ajax_select/js/ajax_select.js
+++ b/ajax_select/static/ajax_select/js/ajax_select.js
@@ -191,12 +191,14 @@
     // Call the original which sets the input (just the pk)
     // calls input.trigger('changed') if >= 1.10
     // and closes the window.
-    if (djangoDismissAddRelatedObjectPopup) {
+    var name = window.windowname_to_id(win.name),
+        $id_input = $('#' + name),
+        is_ajax_select = $id_input.attr('data-ajax-select') === "autocompleteselectmultiple";
+    if (djangoDismissAddRelatedObjectPopup && !is_ajax_select) {
       djangoDismissAddRelatedObjectPopup(win, newId, newRepr);
     } else {
       win.close();
     }
-    var name = window.windowname_to_id(win.name);
     // newRepr is django's repr of object
     // not the Lookup's formatting of it.
     $('#' + name).trigger('didAddPopup', [newId, newRepr]);


### PR DESCRIPTION
Currently it seems that the django-ajax-selects "add another" feature for multiple-select boxes does not work as expected. I'm adding a new item with the modal that gets the ID 82, but the hidden input box will get the value `8282|`, so the ID is entered twice.

![image](https://cloud.githubusercontent.com/assets/88278/19161281/7536d198-8bf3-11e6-9651-10d8a4f4adaf.png)

The problem seems to be in this line:
https://github.com/crucialfelix/django-ajax-selects/blob/1.5.0/ajax_select/static/ajax_select/js/ajax_select.js#L194
The check `if (djangoDismissAddRelatedObjectPopup) {` will ALWAYS evaluate to true, so Django's behaviour is called, which will add the first time ID `82` to the hidden input value, then `$('#' + name).trigger('didAddPopup', [newId, newRepr]);` is called, and kicks in the behaviour of django-ajax-selects which adds the second ID `82` to the value.

The PR fixes it and only calls the django related behaviour if we are operating on a field enhanced by django-ajax-selects.

I'm using Django 1.9.10.