### PR TITLE
Fix #182 - use document.createElement instead of document.write

### DIFF
--- a/ajax_select/static/ajax_select/js/ajax_select.js
+++ b/ajax_select/static/ajax_select/js/ajax_select.js
@@ -1,6 +1,6 @@
+window.addEventListener('load', function() {
 
-(function($) {
-  'use strict';
+  var $ = window.jQuery;
 
   $.fn.autocompleteselect = function(options) {
     return this.each(function() {
@@ -245,4 +245,4 @@
       });
   });
 
-})(window.jQuery);
+}, {once: true});

--- a/ajax_select/static/ajax_select/js/bootstrap.js
+++ b/ajax_select/static/ajax_select/js/bootstrap.js
@@ -1,7 +1,32 @@
-// load jquery and jquery-ui if needed
-// into window.jQuery
-if (typeof window.jQuery === 'undefined') {
-  document.write('<script type="text/javascript"  src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"><\/script><script type="text/javascript"  src="//code.jquery.com/ui/1.10.3/jquery-ui.js"><\/script><link type="text/css" rel="stylesheet" href="//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" />');
-} else if(typeof window.jQuery.ui === 'undefined' || typeof window.jQuery.ui.autocomplete === 'undefined') {
-  document.write('<script type="text/javascript"  src="//code.jquery.com/ui/1.10.3/jquery-ui.js"><\/script><link type="text/css" rel="stylesheet" href="//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" />');
-}
+(function(w) {
+  /**
+   * load jquery and jquery-ui if needed
+   */
+
+  function not(thing) {
+    return typeof thing === 'undefined';
+  }
+
+  function loadJS(src) {
+    var script = document.createElement('script');
+    script.src = src;
+    document.head.appendChild(script);
+  }
+
+  function loadCSS(href) {
+    var script = document.createElement('link');
+    script.href = href;
+    script.type = 'text/css';
+    script.rel = 'stylesheet';
+    document.head.appendChild(script);
+  }
+
+  if (not(w.jQuery)) {
+    loadJS('//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js');
+  }
+
+  if (not(w.jQuery) || not(w.jQuery.ui) || not(w.jQuery.ui.autocomplete)) {
+    loadJS('//code.jquery.com/ui/1.10.3/jquery-ui.js');
+    loadCSS('//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css');
+  }
+})(window);


### PR DESCRIPTION
This avoids warnings from Chrome, avoids possibility of being cancelled on slow
connections.
Page loads faster as the scripts are non-blocking.
Ajax-selects initializes after all scripts are loaded.