### PR TITLE
Use DjangoJSONEncoder - which handles additional django types

### DIFF
--- a/ajax_select/fields.py
+++ b/ajax_select/fields.py
@@ -4,6 +4,7 @@ from ajax_select.registry import registry
 from django import forms
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models.query import QuerySet
 from django.forms.utils import flatatt
 from django.template.defaultfilters import force_escape
@@ -217,7 +218,9 @@ class AutoCompleteSelectMultipleWidget(forms.widgets.SelectMultiple):
             'html_id': self.html_id,
             'current': value,
             'current_ids': current_ids,
-            'current_reprs': mark_safe(json.dumps(initial)),
+            'current_reprs': mark_safe(
+                json.dumps(initial, cls=DjangoJSONEncoder)
+            ),
             'help_text': help_text,
             'extra_attrs': mark_safe(flatatt(final_attrs)),
             'func_slug': self.html_id.replace("-", ""),
@@ -441,8 +444,10 @@ def make_plugin_options(lookup, channel_name, widget_plugin_options, initial):
         po['html'] = True
 
     return {
-        'plugin_options': mark_safe(json.dumps(po)),
-        'data_plugin_options': force_escape(json.dumps(po))
+        'plugin_options': mark_safe(json.dumps(po, cls=DjangoJSONEncoder)),
+        'data_plugin_options': force_escape(
+            json.dumps(po, cls=DjangoJSONEncoder)
+        )
     }
 
 


### PR DESCRIPTION
All supported types: https://docs.djangoproject.com/en/1.11/topics/serialization/#djangojsonencoder

Without this change serialization of:
```python
class Job(models.Model):
    id = models.UUIDField(primary_key=True, default=uuid.uuid4)
```

throws exception:
```
[...]
File "/home/vagrant/env/lib/python3.4/site-packages/ajax_select/fields.py", line 444, in make_plugin_options
    'plugin_options': mark_safe(json.dumps(po)),
  File "/usr/lib/python3.4/json/__init__.py", line 230, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python3.4/json/encoder.py", line 192, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.4/json/encoder.py", line 250, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.4/json/encoder.py", line 173, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: UUID('998109d4-cf99-42d5-af34-c6b7ba16423a') is not JSON serializable
```