### PR TITLE
lookup_channel: don't use target_field to get cast function

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ Compatibility
 - Python >=2.7, 3.3-3.5
 
 
+Running the tests
+-----------------
+
+Just install `requirements-test.txt`, then run `make test`.
+
 Contributors
 ------------
 

--- a/ajax_select/lookup_channel.py
+++ b/ajax_select/lookup_channel.py
@@ -96,7 +96,7 @@ class LookupChannel(object):
         """
         if self.model._meta.pk.rel is not None:
             # Use the type of the field being referenced
-            pk_type = self.model._meta.pk.target_field.to_python
+            pk_type = self.model._meta.pk.rel.field.to_python
         else:
             pk_type = self.model._meta.pk.to_python
 


### PR DESCRIPTION
At least in Django 1.8.18, target_field does not exists for OneToOneField. Using the `field` attribute of the relation fixes the exception and makes my forms to work as expected, but I'm not able to test on other Django versions.  
Also, I'm not sure if it does not break this https://github.com/crucialfelix/django-ajax-selects/issues/153 again. Could someone check that?