### PR TITLE
Fix Lookup.get_objects for inherited models

### DIFF
--- a/ajax_select/fields.py
+++ b/ajax_select/fields.py
@@ -1,11 +1,12 @@
 from __future__ import unicode_literals
+
 import json
-from ajax_select.registry import registry
+
 from django import forms
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.serializers.json import DjangoJSONEncoder
-from django.db.models.query import QuerySet
+from django.db.models import Model
 from django.forms.utils import flatatt
 from django.template.defaultfilters import force_escape
 from django.template.loader import render_to_string
@@ -13,6 +14,9 @@ from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 from django.utils.six import text_type
 from django.utils.translation import ugettext as _
+
+from ajax_select.registry import registry
+
 try:
     from django.urls import reverse
 except ImportError:
@@ -97,7 +101,8 @@ class AutoCompleteSelectWidget(forms.widgets.TextInput):
             'func_slug': self.html_id.replace("-", ""),
             'add_link': self.add_link,
         }
-        context.update(make_plugin_options(lookup, self.channel, self.plugin_options, initial))
+        context.update(
+            make_plugin_options(lookup, self.channel, self.plugin_options, initial))
         templates = (
             'ajax_select/autocompleteselect_%s.html' % self.channel,
             'ajax_select/autocompleteselect.html')
@@ -128,7 +133,8 @@ class AutoCompleteSelectField(forms.fields.CharField):
         )
         widget_kwargs.update(kwargs.pop('widget_options', {}))
         kwargs["widget"] = AutoCompleteSelectWidget(**widget_kwargs)
-        super(AutoCompleteSelectField, self).__init__(max_length=255, *args, **kwargs)
+        super(AutoCompleteSelectField, self).__init__(
+            max_length=255, *args, **kwargs)
 
     def clean(self, value):
         if value:
@@ -139,7 +145,8 @@ class AutoCompleteSelectField(forms.fields.CharField):
                 # or your channel is faulty
                 # out of the scope of this field to do anything more than
                 # tell you it doesn't exist
-                raise forms.ValidationError("%s cannot find object: %s" % (lookup, value))
+                raise forms.ValidationError(
+                    "%s cannot find object: %s" % (lookup, value))
             return objs[0]
         else:
             if self.required:
@@ -195,10 +202,11 @@ class AutoCompleteSelectMultipleWidget(forms.widgets.SelectMultiple):
 
         lookup = registry.get(self.channel)
 
-        if isinstance(value, QuerySet):
-            objects = value
+        values = list(value)
+        if all([isinstance(v, Model) for v in values]):
+            objects = values
         else:
-            objects = lookup.get_objects(value)
+            objects = lookup.get_objects(values)
 
         current_ids = pack_ids([obj.pk for obj in objects])
 
@@ -226,9 +234,10 @@ class AutoCompleteSelectMultipleWidget(forms.widgets.SelectMultiple):
             'func_slug': self.html_id.replace("-", ""),
             'add_link': self.add_link,
         }
-        context.update(make_plugin_options(lookup, self.channel, self.plugin_options, initial))
+        context.update(
+            make_plugin_options(lookup, self.channel, self.plugin_options, initial))
         templates = ('ajax_select/autocompleteselectmultiple_%s.html' % self.channel,
-                    'ajax_select/autocompleteselectmultiple.html')
+                     'ajax_select/autocompleteselectmultiple.html')
         out = render_to_string(templates, context)
         return mark_safe(out)
 
@@ -272,7 +281,8 @@ class AutoCompleteSelectMultipleField(forms.fields.CharField):
                 dh = 'Hold down "Control", or "Command" on a Mac, to select more than one.'
                 django_default_help = _(dh).translate(settings.LANGUAGE_CODE)
                 if django_default_help in translated:
-                    cleaned_help = translated.replace(django_default_help, '').strip()
+                    cleaned_help = translated.replace(
+                        django_default_help, '').strip()
                     # probably will not show up in translations
                     if cleaned_help:
                         help_text = cleaned_help
@@ -361,13 +371,15 @@ class AutoCompleteWidget(forms.TextInput):
             'extra_attrs': mark_safe(flatatt(final_attrs)),
             'func_slug': self.html_id.replace("-", ""),
         }
-        context.update(make_plugin_options(lookup, self.channel, self.plugin_options, initial))
+        context.update(
+            make_plugin_options(lookup, self.channel, self.plugin_options, initial))
         templates = ('ajax_select/autocomplete_%s.html' % self.channel,
                      'ajax_select/autocomplete.html')
         return mark_safe(render_to_string(templates, context))
 
 
 class AutoCompleteField(forms.CharField):
+
     """
     A CharField that uses an AutoCompleteWidget to lookup matching
     and stores the result as plain text.
@@ -414,7 +426,8 @@ def _check_can_add(self, user, related_model):
     if can_add:
         app_label = related_model._meta.app_label
         model = related_model._meta.object_name.lower()
-        self.widget.add_link = reverse('admin:%s_%s_add' % (app_label, model)) + '?_popup=1'
+        self.widget.add_link = reverse(
+            'admin:%s_%s_add' % (app_label, model)) + '?_popup=1'
 
 
 def autoselect_fields_check_can_add(form, model, user):

--- a/ajax_select/lookup_channel.py
+++ b/ajax_select/lookup_channel.py
@@ -94,9 +94,10 @@ class LookupChannel(object):
         Returns:
             list: list of Model objects
         """
+        # Inherited models have a OneToOneField (rather than eg AutoField)
         if self.model._meta.pk.rel is not None:
             # Use the type of the field being referenced
-            pk_type = self.model._meta.pk.target_field.to_python
+            pk_type = self.model._meta.pk.rel.field.to_python
         else:
             pk_type = self.model._meta.pk.to_python
 

--- a/tests/lookups.py
+++ b/tests/lookups.py
@@ -3,10 +3,12 @@ Testing the register and autoloading.
 
 Should not be used by other tests.
 """
-from django.utils.html import escape
 from django.contrib.auth.models import User
-from tests.models import Person, Author
+from django.utils.html import escape
+
 import ajax_select
+
+from tests.models import Author, Person, PersonWithTitle
 
 
 @ajax_select.register('person')
@@ -25,6 +27,18 @@ class PersonLookup(ajax_select.LookupChannel):
 
     def format_item_display(self, obj):
         return "%s<div><i>%s</i></div>" % (escape(obj.name), escape(obj.email))
+
+
+@ajax_select.register('person-with-title')
+class PersonWithTitleLookup(ajax_select.LookupChannel):
+
+    model = PersonWithTitle
+
+    def get_query(self, q, request):
+        return self.model.objects.filter(title__icontains=q)
+
+    def get_result(self, obj):
+        return "{} {}".format(obj.name, obj.title)
 
 
 @ajax_select.register('user')

--- a/tests/models.py
+++ b/tests/models.py
@@ -11,6 +11,18 @@ class Person(models.Model):
         app_label = 'tests'
 
 
+class PersonWithTitle(Person):
+
+    """
+    Testing an inherited model (multi-table)
+    """
+
+    title = models.CharField(max_length=150)
+
+    class Meta:
+        app_label = 'tests'
+
+
 class Author(models.Model):
 
     name = models.CharField(max_length=50)

--- a/tests/test_lookups.py
+++ b/tests/test_lookups.py
@@ -1,21 +1,38 @@
 
-from django.test import TestCase
 from django.contrib.auth.models import User
-from .lookups import UserLookup
+from django.test import TestCase
+
+from tests.lookups import PersonWithTitleLookup, UserLookup
+from tests.models import PersonWithTitle
 
 
 class TestLookups(TestCase):
 
     def test_get_objects(self):
         user1 = User.objects.create(username='user1',
-            email='user1@example.com',
-            password='password')
+                                    email='user1@example.com',
+                                    password='password')
         user2 = User.objects.create(username='user2',
-            email='user2@example.com',
-            password='password')
+                                    email='user2@example.com',
+                                    password='password')
         lookup = UserLookup()
+        # deliberately asking for them backwards:
         users = lookup.get_objects([user2.id, user1.id])
         self.assertEqual(len(users), 2)
+        # to make sure they come back in the order requested
         u2, u1 = users
         self.assertEqual(u1, user1)
         self.assertEqual(u2, user2)
+
+    def test_get_objects_inherited_model(self):
+        """
+        Tests that get_objects works with inherited models
+        """
+        one = PersonWithTitle.objects.create(name='one', title='The One')
+        two = PersonWithTitle.objects.create(name='two', title='The Other')
+        lookup = PersonWithTitleLookup()
+        users = lookup.get_objects([one.id, two.id])
+        self.assertEqual(len(users), 2)
+        u1, u2 = users
+        self.assertEqual(u1, one)
+        self.assertEqual(u2, two)

--- a/tox.ini
+++ b/tox.ini
@@ -16,11 +16,11 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/ajax_select:{toxinidir}/tests
 commands = django-admin.py test tests
 deps =
-  dj17: Django>=1.7,<1.8
-  dj18: Django>=1.8,<1.9
-  dj19: Django>=1.9,<1.10
-  dj110: Django>=1.10,<1.11
-  dj111: Django>=1.11,<1.12
+  dj17: Django>=1.7.11,<1.8
+  dj18: Django>=1.8.18,<1.9
+  dj19: Django>=1.9.13,<1.10
+  dj110: Django>=1.10.8,<1.11
+  dj111: Django>=1.11.5,<1.12
   ; djmaster: https://github.com/django/django/zipball/master
 
 [testenv:py27-flake8]


### PR DESCRIPTION
Note: django > 1.10 should/could use pk.related_field.to_python
but earlier versions need to use pk.rel.field.to_python

They may deprecate rel later but at least we now have test coverage for it.