### PR TITLE
Add info to readme about using outside of admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ class DocumentForm(ModelForm):
     tags = AutoCompleteSelectMultipleField('tags')
 ```
 
+Important - for autocomplete to work outside of admin, you must include `{{ form.media }}` in your form and explicitly allow non-staff to use (if desired)  
+see: http://django-ajax-selects.readthedocs.io/en/latest/Outside-of-Admin.html  
+and: http://django-ajax-selects.readthedocs.io/en/latest/LookupChannel.html
+
 ## Fully customizable
 
 * Customize search query

--- a/README.md
+++ b/README.md
@@ -47,9 +47,16 @@ class DocumentForm(ModelForm):
     tags = AutoCompleteSelectMultipleField('tags')
 ```
 
-Important - for autocomplete to work outside of admin, you must include `{{ form.media }}` in your form and explicitly allow non-staff to use (if desired)  
-see: http://django-ajax-selects.readthedocs.io/en/latest/Outside-of-Admin.html  
-and: http://django-ajax-selects.readthedocs.io/en/latest/LookupChannel.html
+This will now work in the Django Admin.
+
+To use a form outside, be sure to include `form.media` on the template where you place the form:
+
+```html
+{{ form.media }}
+{{ form }}
+```
+
+Read the full documention here: [outside of the admin](http://django-ajax-selects.readthedocs.io/en/latest/Outside-of-Admin.html)
 
 ## Fully customizable
 


### PR DESCRIPTION
makes readme more informative

without {{form.media}} ajax selects will fail silently (happily, lots of other people have similar issues, so easy to lookup).
Even once fixed