### PR TITLE
(patch) Allow specify callback as source

### DIFF
--- a/ajax_select/static/ajax_select/js/ajax_select.js
+++ b/ajax_select/static/ajax_select/js/ajax_select.js
@@ -146,6 +146,21 @@
       return;
     }
     // console.log('activating', $inp);
+
+    try {
+      if (eval("typeof " + opts.source) === "function") {
+        // console.log("this.id: " + $inp.attr('id') + ", opts.source (Callback):" + opts.source);
+        try {
+          opts.source = eval(opts.source);
+          // console.log("loaded successfully!");
+        } catch(err) {
+          console.error(err);
+        }
+      }
+    } catch(err) {
+      // console.log("this.id: " + $inp.attr('id') + ", opts.source (URL):" + opts.source);
+    }
+
     callback($inp, opts);
     $inp.data('_ajax_select_inited_', true);
   }


### PR DESCRIPTION
refs #231 Instead of load an static URL you can define a callback function
able of add some parameters taken at execution time.

```python

class ReleaseForm(ModelForm):
    group = make_ajax_field(Release, 'group', 'group',
                            show_help_text=True, required=True)
    new_label = AutoCompleteSelectField('search_lookup',
                                        plugin_options={
                                            'autoFocus': True,
                                            'minLength': 2,
                                            'source': 'search_new_label'
                                        })
```

```html

<!-- template.html -->
<script type="text/javascript">
function search_new_label(request, response) {
  request["id_group"] = $("#id_group").val();
  var url_tmp ='http://localhost:8000/lookups/ajax_lookup/search_labels'
  $.ajax({
    type: "GET",
    url: url_tmp,
    data: request,
    success: function(data) {
      response(data);
    }
  });
}
</script>

```

```python

class LabelLookup(LookupChannel):
    # ...
    def get_query(self, q, request):
        qs = Label.objects.filter(name__icontains=q)
        id_group = request.GET.get('id_group')
        if id_group:
            qs = qs.filter(make__id=id_group)
        return qs

```