### PR TITLE
Django 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - TOX_ENV=py37-dj111
   - TOX_ENV=py37-dj20
   - TOX_ENV=py37-dj21
+  - TOX_ENV=py37-dj30
 before_install:
   - pyenv install 2.7 --skip-existing
   - pyenv install 3.7 --skip-existing

--- a/ajax_select/fields.py
+++ b/ajax_select/fields.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import json
+from six import text_type
 from django import forms
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -11,7 +12,6 @@ from django.template.loader import render_to_string
 from django.utils.encoding import force_text
 from django.utils.module_loading import import_string
 from django.utils.safestring import mark_safe
-from django.utils.six import text_type
 from django.utils.translation import ugettext as _
 
 from ajax_select.registry import registry

--- a/ajax_select/fields.py
+++ b/ajax_select/fields.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import json
+import sys
 from six import text_type
 from django import forms
 from django.conf import settings
@@ -12,9 +13,13 @@ from django.template.loader import render_to_string
 from django.utils.encoding import force_text
 from django.utils.module_loading import import_string
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
 
 from ajax_select.registry import registry
+
+if sys.version_info.major >= 3:
+    from django.utils.translation import gettext as _
+else:
+    from django.utils.translation import ugettext as _
 
 try:
     from django.urls import reverse

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     description="Edit ForeignKey, ManyToManyField and CharField in Django Admin using jQuery UI AutoComplete.",
     author="Chris Sattinger",
     author_email="crucialfelix@gmail.com",
+    install_requires=["six"],
     url="https://github.com/crucialfelix/django-ajax-selects/",
     packages=["ajax_select"],
     package_data={

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@
 envlist =
   {py27,py37}-flake8,
   {py27,py37}-{dj18,dj19,dj110,dj111}
-  py37-{dj20,dj21}
+  py37-{dj20,dj21,dj30}
 
 [testenv]
 setenv =
@@ -22,6 +22,7 @@ deps =
   dj111: Django>=1.11.8,<1.12
   dj20: Django>=2.0,<2.1
   dj21: Django>=2.1,<2.2
+  dj30: Django>=3,<3.1
   ; djmaster: https://github.com/django/django/zipball/master
 
 [testenv:py27-flake8]


### PR DESCRIPTION
This PR does the following for Django 3 compatibility:

- Removes references to `django.utils.six` since it has been removed from django. Instead, added `six` as a dependency and use it directly.
- Replaced `ugettext_` with `gettext_` if the python version is >= 3 (deprecated in Django 3).