### PR TITLE
Feature/fix six py2 import

### DIFF
--- a/ajax_select/fields.py
+++ b/ajax_select/fields.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 
 import json
 import sys
-from six import text_type
+
+from ajax_select.registry import registry
 from django import forms
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -14,7 +15,11 @@ from django.utils.encoding import force_text
 from django.utils.module_loading import import_string
 from django.utils.safestring import mark_safe
 
-from ajax_select.registry import registry
+try:
+    from six import text_type
+except ImportError:
+    from django.utils.six import text_type
+
 
 if sys.version_info.major >= 3:
     from django.utils.translation import gettext as _

--- a/ajax_select/static/ajax_select/css/ajax_select.css
+++ b/ajax_select/static/ajax_select/css/ajax_select.css
@@ -6,19 +6,19 @@
   padding: 0.25em 0;
 }
 form .aligned .results_on_deck {
-  padding-left: 38px;
-  margin-left: 7em;
+  padding-left: 14px;
+  margin-left: 160px;
 }
 .results_on_deck > div {
-  margin-bottom: 0.5em;
+  margin: 0.5em 0;
 }
 .ui-autocomplete-loading {
-  background:  url('../images/loading-indicator.gif') no-repeat;
+  background: url("../images/loading-indicator.gif") no-repeat;
   background-origin: content-box;
   background-position: right;
 }
 ul.ui-autocomplete {
-	/*
+  /*
   this is the dropdown menu.
 
   if max-width is not set and you are using django-admin

--- a/example/example/lookups.py
+++ b/example/example/lookups.py
@@ -1,12 +1,16 @@
 from __future__ import unicode_literals
 
-from django.db.models import Q
-from django.utils.html import escape
-from django.utils.six import text_type
-from example.models import Group, Person, Song
-
 import ajax_select
 from ajax_select import LookupChannel
+from django.db.models import Q
+from django.utils.html import escape
+
+from example.models import Group, Person, Song
+
+try:
+    from six import text_type
+except ImportError:
+    from django.utils.six import text_type
 
 
 class PersonLookup(LookupChannel):

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -63,7 +63,6 @@ AJAX_LOOKUP_CHANNELS = {
 
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
     # ('Your Name', 'your_email@domain.com'),
@@ -122,32 +121,26 @@ SECRET_KEY = '=9fhrrwrazha6r_m)r#+in*@n@i322ubzy4r+zz%wz$+y(=qpb'
 
 ROOT_URLCONF = 'example.urls'
 
-# Django < 1.8
-TEMPLATE_DIRS = (
-    # Put strings here, like "/home/html/django_templates"
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
-)
+ROOT_URLCONF = "example.urls"
 
-# Django >= 1.8
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [
             # insert your TEMPLATE_DIRS here
         ],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
                 # Insert your TEMPLATE_CONTEXT_PROCESSORS here or use this
                 # list if you haven't customized them:
-                'django.contrib.auth.context_processors.auth',
-                'django.template.context_processors.debug',
-                'django.template.context_processors.i18n',
-                'django.template.context_processors.media',
-                'django.template.context_processors.static',
-                'django.template.context_processors.tz',
-                'django.contrib.messages.context_processors.messages',
+                "django.contrib.auth.context_processors.auth",
+                "django.template.context_processors.debug",
+                "django.template.context_processors.i18n",
+                "django.template.context_processors.media",
+                "django.template.context_processors.static",
+                "django.template.context_processors.tz",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
         # TEMPLATE_LOADERS = (


### PR DESCRIPTION
Fixes `import six` if using Django  < 2
Remove deprecated settings from example app
Fix alignment of "results on deck"
