### PR TITLE
Add app_name for Django >= 2.0

### DIFF
--- a/ajax_select/fields.py
+++ b/ajax_select/fields.py
@@ -460,7 +460,7 @@ def make_plugin_options(lookup, channel_name, widget_plugin_options, initial):
     po.update(getattr(lookup, 'plugin_options', {}))
     po.update(widget_plugin_options)
     if not po.get('source'):
-        po['source'] = reverse('ajax_lookup', kwargs={'channel': channel_name})
+        po['source'] = reverse('ajax_lookup:ajax_lookup', kwargs={'channel': channel_name})
 
     # allow html unless explicitly set
     if po.get('html') is None:

--- a/ajax_select/urls.py
+++ b/ajax_select/urls.py
@@ -2,6 +2,8 @@ from django.conf.urls import url
 
 from ajax_select import views
 
+app_name = 'ajax_lookup'
+
 urlpatterns = [
     url(r'^ajax_lookup/(?P<channel>[-\w]+)$',
         views.ajax_lookup,


### PR DESCRIPTION
Since Django 2.0 `app_name` in urls.py has been required to use namespaces.  This shouldn't affect older versions of Django and it will handle a warning displayed by the code.   

See here:
https://docs.djangoproject.com/en/3.0/topics/http/urls/#url-namespaces-and-included-urlconfs
https://code.djangoproject.com/ticket/28691

EDIT:  I stand corrected.   This does break Django 1.8.   This fix would probably cause a version bump of this library.  

Perhaps a 2.0 that only supports Django 2+ and by extension only Py3.5+ ?  :D

(Support for Django 1.8 ended on April 1, 2018. )