### PR TITLE
Fix Django 3.2 and 4.0 deprecation warnings

### DIFF
--- a/ajax_select/__init__.py
+++ b/ajax_select/__init__.py
@@ -13,4 +13,9 @@ from ajax_select.lookup_channel import LookupChannel  # noqa
 # and any specified in settings.AJAX_LOOKUP_CHANNELS
 # It will do this after all apps are imported.
 from django.apps import AppConfig  # noqa
-default_app_config = 'ajax_select.apps.AjaxSelectConfig'
+
+# Django 3.2+ does not need default_app_config set.
+# Remove this once django <3.2 support is removed
+import django
+if django.VERSION < (3, 2):
+    default_app_config = 'ajax_select.apps.AjaxSelectConfig'

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -5,6 +5,8 @@ DATABASES = {
         "ENGINE": "django.db.backends.sqlite3",
     }
 }
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
 ROOT_URLCONF = "tests.urls"
 INSTALLED_APPS = [
     "django.contrib.auth",

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.conf.urls.static import static
 from django.contrib import admin
 
@@ -8,6 +8,6 @@ from ajax_select import urls as ajax_select_urls
 admin.autodiscover()
 
 urlpatterns = [
-                  url(r'^ajax_lookups/', include(ajax_select_urls)),
-                  url(r'^admin/', admin.site.urls),
+                  path('ajax_lookups/', include(ajax_select_urls)),
+                  path('admin/', admin.site.urls),
               ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/tox.ini
+++ b/tox.ini
@@ -7,17 +7,19 @@
 [tox]
 envlist =
   {py38}-flake8,
-  py38-{dj22,dj30,dj31}
-
+  py38-{dj22,dj30,dj31,dj32,dj40}
 [testenv]
 setenv =
     DJANGO_SETTINGS_MODULE=tests.settings
     PYTHONPATH = {toxinidir}:{toxinidir}/ajax_select:{toxinidir}/tests
-commands = django-admin.py test tests
+    PYTHONWARNINGS = default
+commands = django-admin test tests
 deps =
   dj22: Django>=2.2,<2.3
   dj30: Django>=3,<3.1
   dj31: Django>=3.1,<3.2
+  dj32: Django>=3.2,<3.3
+  dj40: Django>=4,<4.1
   ; djmaster: https://github.com/django/django/zipball/master
 
 [testenv:py38-flake8]


### PR DESCRIPTION
* Adds django 3.2 and 4.0 to tox
* Setup tox to display all warnings
* Fixes the following warnings:

RemovedInDjango40Warning: django-admin.py is deprecated in favor of django-admin.

tests/urls.py:11: RemovedInDjango40Warning: django.conf.urls.url() is deprecated in favor of django.urls.re_path().
  url(r'^ajax_lookups/', include(ajax_select_urls)),

tests.Author: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
    HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.

RemovedInDjango41Warning: 'ajax_select' defines default_app_config = 'ajax_select.apps.AjaxSelectConfig'. Django now detects this configuration automatically. You can remove default_app_config.
