### PR TITLE
Setup Github Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Tests
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the develop branch
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10']
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox

--- a/ajax_select/__init__.py
+++ b/ajax_select/__init__.py
@@ -13,4 +13,9 @@ from ajax_select.lookup_channel import LookupChannel  # noqa
 # and any specified in settings.AJAX_LOOKUP_CHANNELS
 # It will do this after all apps are imported.
 from django.apps import AppConfig  # noqa
-default_app_config = 'ajax_select.apps.AjaxSelectConfig'
+
+# Django 3.2+ does not need default_app_config set.
+# Remove this once django <3.2 support is removed
+import django
+if django.VERSION < (3, 2):
+    default_app_config = 'ajax_select.apps.AjaxSelectConfig'

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -5,6 +5,8 @@ DATABASES = {
         "ENGINE": "django.db.backends.sqlite3",
     }
 }
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
 ROOT_URLCONF = "tests.urls"
 INSTALLED_APPS = [
     "django.contrib.auth",

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.conf.urls.static import static
 from django.contrib import admin
 
@@ -8,6 +8,6 @@ from ajax_select import urls as ajax_select_urls
 admin.autodiscover()
 
 urlpatterns = [
-                  url(r'^ajax_lookups/', include(ajax_select_urls)),
-                  url(r'^admin/', admin.site.urls),
+                  path('ajax_lookups/', include(ajax_select_urls)),
+                  path('admin/', admin.site.urls),
               ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,14 @@
 [tox]
 envlist =
   {py38}-flake8,
-  py38-{dj22,dj30,dj31,dj32,dj40}
+  {py38,py39,py310}-{dj22,dj30,dj31,dj32,dj40}
+
+[gh-actions]
+python =
+    3.8: py38
+    3.9: py39
+    3.10: py310
+
 [testenv]
 setenv =
     DJANGO_SETTINGS_MODULE=tests.settings

--- a/tox.ini
+++ b/tox.ini
@@ -7,17 +7,19 @@
 [tox]
 envlist =
   {py38}-flake8,
-  py38-{dj22,dj30,dj31}
-
+  py38-{dj22,dj30,dj31,dj32,dj40}
 [testenv]
 setenv =
     DJANGO_SETTINGS_MODULE=tests.settings
     PYTHONPATH = {toxinidir}:{toxinidir}/ajax_select:{toxinidir}/tests
-commands = django-admin.py test tests
+    PYTHONWARNINGS = default
+commands = django-admin test tests
 deps =
   dj22: Django>=2.2,<2.3
   dj30: Django>=3,<3.1
   dj31: Django>=3.1,<3.2
+  dj32: Django>=3.2,<3.3
+  dj40: Django>=4,<4.1
   ; djmaster: https://github.com/django/django/zipball/master
 
 [testenv:py38-flake8]


### PR DESCRIPTION
Closes #278 
Please review and merge #289 first as this builds on that.

I created a simple GitHub action to run tox in python 3.8, 3.9 and 3.10. It currently only runs the flake8 command in python 3.8 because the other versions were causing an error that I don't understand yet. I think it might be possible to also run flake8 as a separate GitHub action. I'll look into it.

Let me know what you think and if you have any suggestions / changes. This is my first time working with GitHub actions, but so far it seems  pretty easy.

This uses the [tox-gh-actions](https://github.com/ymyzk/tox-gh-actions) plugin to help with the multiple python versions.